### PR TITLE
add unitExternalId to data point response, to match the json repsonse

### DIFF
--- a/v1/timeseries/data_point_list_response.proto
+++ b/v1/timeseries/data_point_list_response.proto
@@ -13,6 +13,7 @@ message DataPointListItem {
     bool isStep = 7;
     string unit = 8;
     string nextCursor = 9;
+    string unitExternalId = 10;
 
     oneof datapointType {
         NumericDatapoints numericDatapoints = 3;


### PR DESCRIPTION
It's not added to the backend yet, so for now it should just return the default, empty string