### PR TITLE
Remove excess whitespace in data_points.proto

### DIFF
--- a/v1/timeseries/data_points.proto
+++ b/v1/timeseries/data_points.proto
@@ -4,7 +4,6 @@ package com.cognite.v1.timeseries.proto;
 
 option java_multiple_files = true;
 
-
 message Status {
     int64 code = 1;
     string symbol = 2;


### PR DESCRIPTION
Python sdk autolinted the proto file, and then checked for equality, which then failed because of the extra whitespace