### PR TITLE
Add support for status codes for strings

### DIFF
--- a/v1/timeseries/data_points.proto
+++ b/v1/timeseries/data_points.proto
@@ -23,6 +23,8 @@ message NumericDatapoints {
 message StringDatapoint {
     int64 timestamp = 1;
     string value = 2;
+    Status status = 3;
+    bool nullValue = 4;
 }
 
 message StringDatapoints {


### PR DESCRIPTION
Should be in draft until support has been added to the time series backend.